### PR TITLE
Opened API for deprecated HTTP method calls

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,6 +1,9 @@
+parameters:
+    ci.restclient.class: Ci\RestClientBundle\Services\RestClient
+
 services:
     ci.restclient:
-        class: Ci\RestClientBundle\Services\RestClient
+        class: %ci.restclient.class%
         arguments: [ @ci.curl ]
     ci.curl:
         class: Ci\RestClientBundle\Services\Curl

--- a/Services/RestClient.php
+++ b/Services/RestClient.php
@@ -25,12 +25,13 @@ namespace Ci\RestClientBundle\Services;
  * @copyright 2015 TeeAge-Beatz UG
  */
 class RestClient implements RestInterface {
+
     /**
      * This variable stores the curl instance created through curl initiation
      *
      * @var Curl
      */
-    private $curl;
+    protected $curl;
 
     /**
      * Constructor

--- a/Traits/Assertions.php
+++ b/Traits/Assertions.php
@@ -57,7 +57,7 @@ trait Assertions {
     private function assertHttpMethod($method) {
         if (!$this->assertString($method)) return false;
         $validHttpMethods = array(
-            'GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT', 'PATCH'
+            'GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT', 'PATCH', 'LINK', 'UNLINK'
         );
         if (!in_array($method, $validHttpMethods)) return false;
         return true;

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "target-dir" : "Ci/RestClientBundle",
   "extra" : {
     "branch-alias" : {
-      "dev-master" : "0.2-dev"
+      "dev-master" : "0.3-dev"
     }
   }
 }


### PR DESCRIPTION
There are some HTTP methods that are deprecated. We cannot provide them in this bundle because we are not able to test them properly. So if you want to use HTTP methods like LINK or UNLINK you can now extend the RestClient service and add these methods by yourself.

```php
namespace Acme\MyBundle\Services;

use Ci\RestClientBundle\Services;

ExtendendRestClient extends RestClient {
    /**
     * {@inheritdoc}
     */
    public function link($url, array $options = array()) {
        return $this->curl->sendRequest($url, 'LINK', $options);
    }

    /**
     * {@inheritdoc}
     */
    public function unlink($url, array $options = array()) {
        return $this->curl->sendRequest($url, 'UNLINK', $options);
    }
}
```

Afterwards override the parameter "ci.restclient.class" in your applications parameters configuration with your new one (in this case "Acme\MyBundle\Services\ExtendedRestClient").

```yml
parameters:
    ci.restclient.class: Acme\MyBundle\Services\ExtendedRestClient
```