### PR TITLE
Allow CURLOPT_SSL_VERIFYPEER to be set

### DIFF
--- a/Resources/config/curl_config.yml
+++ b/Resources/config/curl_config.yml
@@ -8,3 +8,4 @@ ci_rest_client:
         CURLOPT_CRLF:           true
         CURLOPT_SSLVERSION:     3
         CURLOPT_FOLLOWLOCATION: true
+        CURLOPT_SSL_VERIFYPEER: true

--- a/Services/Curl.php
+++ b/Services/Curl.php
@@ -155,7 +155,6 @@ class Curl implements CurlInterface {
      */
     private function setURL($url) {
         $this->curlOptionsHandler->setOption(CURLOPT_URL, $url);
-        $this->curlOptionsHandler->setOption(CURLOPT_SSL_VERIFYPEER, $this->assertUrlHttps($url));
         return $this;
     }
 

--- a/Traits/Assertions.php
+++ b/Traits/Assertions.php
@@ -62,14 +62,4 @@ trait Assertions {
         if (!in_array($method, $validHttpMethods)) return false;
         return true;
     }
-
-    /**
-     * Validates/Checks the HTTP or HTTPS from given URL
-     *
-     * @param  string $url
-     * @return $this
-     */
-    private function assertUrlHttps($url) {
-        return preg_match('#^https:\/\/#', $url) && $this->assertUrl($url);
-    }
 }


### PR DESCRIPTION
CURLOPT_SSL_VERIFYPEER was set by default based on the url protocol (HTTP  or HTTPS), This PR allows to configure it manually