### PR TITLE
Add quotation marks to yaml services definitions to avoid deprecation…

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,13 +1,13 @@
 parameters:
-    circle.restclient.class: Circle\RestClientBundle\Services\RestClient
+    circle.restclient.class: "Circle\\RestClientBundle\\Services\\RestClient"
 
 services:
     circle.restclient:
-        class: %circle.restclient.class%
+        class: "%circle.restclient.class%"
         arguments: [ "@circle.curl" ]
     circle.curl:
-        class: Circle\RestClientBundle\Services\Curl
+        class: "Circle\\RestClientBundle\\Services\\Curl"
         arguments: [ "@circle.curl.options.handler" ]
     circle.curl.options.handler:
-        class: Circle\RestClientBundle\Services\CurlOptionsHandler
-        arguments: [ %circle.restclient.curl.defaults% ]
+        class: "Circle\\RestClientBundle\\Services\\CurlOptionsHandler"
+        arguments: [ "%circle.restclient.curl.defaults%" ]


### PR DESCRIPTION
… warnings

Due to deprecated usage of `%service.name%` and` Namespace\Some\Class` in YAML files - described here: http://symfony.com/blog/new-in-symfony-2-8-yaml-deprecations I updated `services.yml ` to get rid of  warnings like:
`Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0: (...)`
in projects based on Symfony 3.x