### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "license" : [
     "GPL"
   ],
-  "require-dev" : {
+  "require" : {
     "php": ">=5.4",
     "ext-curl": "*",
     "symfony/http-kernel": ">=2.1",


### PR DESCRIPTION
_require-dev_ components are really _require_ ones. So that, in my case, after _composer require_ symfony console crashed because _curl extension_ was not installed.