### PR TITLE
Prevent from making nested arrays of headers

### DIFF
--- a/Parsers/HTTPHeadersParser.php
+++ b/Parsers/HTTPHeadersParser.php
@@ -47,11 +47,15 @@ class HTTPHeadersParser {
 
            if (!isset($carry[$match[1]])) {
                $carry[$match[1]] = trim($match[2]);
-           } elseif (is_array($carry[$match[1]])) {
-               $carry[$match[1]][] = trim($match[2]);
-           } else {
-               $carry[$match[1]] = [$carry[$match[1]], trim($match[2])];
+               return $carry;
            }
+           
+           if (is_array($carry[$match[1]])) {
+               $carry[$match[1]][] = trim($match[2]);      
+               return $carry;
+           }
+           
+           $carry[$match[1]] = [$carry[$match[1]], trim($match[2])];
 
            return $carry;
        }, []);

--- a/Parsers/HTTPHeadersParser.php
+++ b/Parsers/HTTPHeadersParser.php
@@ -45,7 +45,13 @@ class HTTPHeadersParser {
                return strtoupper($matches[0]);
            }, strtolower(trim($match[1])));
 
-           $carry[$match[1]] = isset($carry[$match[1]]) ? [$carry[$match[1]], $match[2]] : trim($match[2]);
+           if (!isset($carry[$match[1]])) {
+               $carry[$match[1]] = trim($match[2]);
+           } elseif (is_array($carry[$match[1]])) {
+               $carry[$match[1]][] = trim($match[2]);
+           } else {
+               $carry[$match[1]] = [$carry[$match[1]], trim($match[2])];
+           }
 
            return $carry;
        }, []);

--- a/Tests/Functional/Parsers/HTTPHeadersParserTest.php
+++ b/Tests/Functional/Parsers/HTTPHeadersParserTest.php
@@ -30,7 +30,7 @@ use Circle\RestClientBundle\Parsers\HTTPHeadersParser;
  *
  * @SuppressWarnings("PHPMD.StaticAccess")
  */
-class ResponseHeadersTest extends \PHPUnit_Framework_TestCase {    
+class ResponseHeadersTest extends \PHPUnit_Framework_TestCase {
     
     /**
      * @test
@@ -66,13 +66,14 @@ class ResponseHeadersTest extends \PHPUnit_Framework_TestCase {
      */
     public function testParseCookie() {
         $headers = "Set-Cookie: foo=bar\r\n".
-            "Set-Cookie: baz=quux\r\n";
+            "Set-Cookie: baz=quux\r\n".
+            "Set-Cookie: quux=baz\r\n";
         $returnValue = HTTPHeadersParser::parse($headers);
         $this->assertTrue(is_array($returnValue));
         
         $this->assertTrue(isset($returnValue['Set-Cookie']));
         $this->assertTrue(is_array($returnValue['Set-Cookie']));
-        $this->assertEquals(count($returnValue['Set-Cookie']), 2);
+        $this->assertEquals(count($returnValue['Set-Cookie']), 3);
     }
     
     /**


### PR DESCRIPTION
When using more than 2 occurrences of the same header, the `HTTPHeadersParser` creates nested arrays instead of a flat structure. This causes a trouble with further processing (e.x. cookie handling).

For the following header:
```php
$headers = "Set-Cookie: foo=bar\r\n".
    "Set-Cookie: baz=quux\r\n".
    "Set-Cookie: quux=baz\r\n";
$returnValue = HTTPHeadersParser::parse($headers);
var_dump($returnValue);
```
The result is:
```
array(1) {
  ["Set-Cookie"]=> array(2) {
    [0]=> array(2) {
      [0]=> string(7) "foo=bar"
      [1]=> string(8) "baz=quux"
    }
    [1]=> string(8) "quux=baz"
  }
}
```

Instead of:
```
array(1) {
  ["Set-Cookie"]=> array(3) {
    [0]=> string(7) "foo=bar"
    [1]=> string(8) "baz=quux"
    [2]=> string(8) "quux=baz"
  }
}
```